### PR TITLE
:bug: Fixing useValueHistory misuse of array.prototype.filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -743,3 +743,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Updating useGlobalEvent ref to the provided function
+
+## [1.0.3] - 2022-01-26
+
+### Fixed
+
+- Updating useValueHistory's misuse of array.prototype.filter to update history.current

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beautiful-react-hooks",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A collection of beautiful (and hopefully useful) React hooks to speed-up your components and hooks development",
   "main": "index.js",
   "module": "esm/index.js",

--- a/src/useValueHistory.ts
+++ b/src/useValueHistory.ts
@@ -13,7 +13,7 @@ const useValueHistory = <T = unknown>(value: T, distinct = false): T[] => {
     history.current.push(value)
 
     if (distinct) {
-      history.current.filter(distinctValues)
+      history.current = history.current.filter(distinctValues)
     }
   }, [value])
 

--- a/test/useValueHistory.spec.js
+++ b/test/useValueHistory.spec.js
@@ -22,4 +22,14 @@ describe('useValueHistory', () => {
 
     expect(result.current).to.deep.equal([1, 2, 3])
   })
+
+  it('should return the history of the unique given value', async () => {
+    const { result, rerender } = renderHook((value) => useValueHistory(value, true), { initialProps: 1 })
+
+    rerender(2)
+    rerender(1)
+    rerender(1)
+
+    expect(result.current).to.deep.equal([1, 2])
+  })
 })


### PR DESCRIPTION
## Description
fix useValueHistory bug when second parameter `distinct` set to `true` and update relevant test-case.

## Related Issue
close #322 