### PR TITLE
fix type definition on useResizeObserver

### DIFF
--- a/src/useResizeObserver.ts
+++ b/src/useResizeObserver.ts
@@ -14,7 +14,7 @@ export type DOMRectValues = Pick<DOMRectReadOnly, 'bottom' | 'height' | 'left' |
  * @param debounceTimeout
  * @returns {undefined}
  */
-const useResizeObserver = <T extends HTMLElement>(elementRef: MutableRefObject<T>, debounceTimeout: number = 100): DOMRectValues => {
+const useResizeObserver = <T extends HTMLElement>(elementRef: MutableRefObject<T>, debounceTimeout: number = 100): DOMRectValues | undefined => {
   const isSupported = isApiSupported('ResizeObserver')
   const observerRef = useRef<ResizeObserver>(null)
   const [DOMRect, setDOMRect] = useState<DOMRectValues>()


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When using `useResizeObserver`, I discovered that the definition of the return type of this hook was misleading. `DOMRect` is initialized to `undefined`, and upon the first run of this hook, the return value can be undefined. In fact, the docs all show that you should check for the existence of `DOMRect` before doing anything with the return value. That should be reflected in the types.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #325 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
TypeScript should be used to help consumers understand the potential values a variable could be. The return type of this function being inaccurate can cause consumers to inaccurately handle it and expect it to always be defined.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Linked locally into my project using this function and verified that it correctly reported that it was potentially undefined.

## Screenshots (if appropriate):
