### PR TITLE
Update MutableRefObject to RefObject where appropriate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -754,3 +754,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Type definitions on useResizeObserver
+
+## [1.0.4] - 2022-01-27
+
+### Fixed
+
+- Refs are typed as RefObject<T>, which is more correct as they are React-managed refs.

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -18,3 +18,19 @@ then just import any hook described by the documentation in your React component
 import { useSomeHook } from 'beautiful-react-hooks'
 import useSomeHook from 'beautiful-react-hoks/useSomeHook'
 ```
+
+## Working with Refs in TypeScript
+
+The documentation of this module is written in JavaScript, so you will see a lot of this:
+
+```javascript
+const ref = useRef()
+```
+
+If you are in a TypeScript project, you should declare your ref as a `RefObject<T extends HTMLElement>`. For example:
+
+```ts
+const ref = useRef<HTMLDivElement>(null);
+```
+
+See [here](https://dev.to/wojciechmatuszewski/mutable-and-immutable-useref-semantics-with-react-typescript-30c9) for information on the difference between a `MutableRefObject` and a `RefObject`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beautiful-react-hooks",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A collection of beautiful (and hopefully useful) React hooks to speed-up your components and hooks development",
   "main": "index.js",
   "module": "esm/index.js",

--- a/src/shared/assignEventOnMount.ts
+++ b/src/shared/assignEventOnMount.ts
@@ -1,7 +1,7 @@
-import { MutableRefObject, useEffect } from 'react'
+import { MutableRefObject, RefObject, useEffect } from 'react'
 
 const assignEventOnMount = <T extends HTMLElement, E extends Event = Event>
-  (targetRef: MutableRefObject<T>, handler: MutableRefObject<(e: E) => unknown>, eventName: string) => {
+  (targetRef: RefObject<T>, handler: MutableRefObject<(e: E) => unknown>, eventName: string) => {
   useEffect(() => {
     const cb = (mouseEvent: E) => {
       if (handler && handler.current) {

--- a/src/useDrag.ts
+++ b/src/useDrag.ts
@@ -1,4 +1,4 @@
-import { MutableRefObject, useState } from 'react'
+import { RefObject, useState } from 'react'
 import useDragEvents from './useDragEvents'
 
 export type UseDragOptions = {
@@ -15,7 +15,7 @@ const defaultOptions: UseDragOptions = {
   transferFormat: 'text',
 }
 
-const useDrag = <T extends HTMLElement>(targetRef: MutableRefObject<T>, options = defaultOptions): boolean => {
+const useDrag = <T extends HTMLElement>(targetRef: RefObject<T>, options = defaultOptions): boolean => {
   const { onDragStart, onDragEnd } = useDragEvents<T>(targetRef, true)
   const [isDragging, setIsDragging] = useState<boolean>(false)
   const opts: UseDragOptions = { ...defaultOptions, ...(options || {}) }

--- a/src/useDragEvents.ts
+++ b/src/useDragEvents.ts
@@ -1,11 +1,11 @@
-import { MutableRefObject, useEffect } from 'react'
+import { MutableRefObject, RefObject, useEffect } from 'react'
 import safeHasOwnProperty from './shared/safeHasOwnProperty'
 import createCbSetterErrorProxy from './shared/createCbSetterErrorProxy'
 import useHandlerSetterRef from './shared/useHandlerSetterRef'
 import { CallbackSetter } from './shared/types'
 
 const assignDragEventOnMount = <T extends HTMLElement>
-  (targetRef: MutableRefObject<T>, handlerRef: MutableRefObject<CallbackSetter<DragEvent>>, eventName: string) => {
+  (targetRef: RefObject<T>, handlerRef: MutableRefObject<CallbackSetter<DragEvent>>, eventName: string) => {
   useEffect(() => {
     const cb = (dragEvent: DragEvent) => {
       if (handlerRef && handlerRef.current) {
@@ -45,7 +45,7 @@ type DragEventsMap = {
  * Returned callback setters: `onDrag`, `onDrop`, `onDragEnter`, `onDragEnd`, `onDragExit`, `onDragLeave`,
  * `onDragOver`, `onDragStart`;
  */
-const useDragEvents = <T extends HTMLElement>(targetRef: MutableRefObject<T>, setDraggable: boolean = true): DragEventsMap => {
+const useDragEvents = <T extends HTMLElement>(targetRef: RefObject<T>, setDraggable: boolean = true): DragEventsMap => {
   const [onDrag, setOnDrag] = useHandlerSetterRef<DragEventCallback>()
   const [onDrop, setOnDrop] = useHandlerSetterRef<DragEventCallback>()
   const [onDragEnter, setOnDragEnter] = useHandlerSetterRef<DragEventCallback>()

--- a/src/useDropZone.ts
+++ b/src/useDropZone.ts
@@ -1,10 +1,10 @@
-import { MutableRefObject, useState } from 'react'
+import { RefObject, useState } from 'react'
 import useDragEvents from './useDragEvents'
 import { CallbackSetter } from './shared/types'
 
 export type DropZoneState = { isOver: boolean, onDrop: CallbackSetter<(event: DragEvent) => any> }
 
-const useDropZone = <T extends HTMLElement>(targetRef: MutableRefObject<T>): DropZoneState => {
+const useDropZone = <T extends HTMLElement>(targetRef: RefObject<T>): DropZoneState => {
   const { onDrop, onDragOver, onDragLeave } = useDragEvents<T>(targetRef, false)
   const [isOver, setIsOver] = useState<boolean>(false)
 

--- a/src/useHorizontalSwipe.ts
+++ b/src/useHorizontalSwipe.ts
@@ -1,4 +1,4 @@
-import { MutableRefObject } from 'react'
+import { RefObject } from 'react'
 import useSwipe, { UseSwipeOptions } from './useSwipe'
 
 const defaultOptions: UseSwipeOptions = {
@@ -9,7 +9,7 @@ const defaultOptions: UseSwipeOptions = {
 /**
  * A shortcut to useSwipe (with horizontal options)
  */
-const useHorizontalSwipe = <T extends HTMLElement>(ref: MutableRefObject<T> = null, options: UseSwipeOptions = defaultOptions) => {
+const useHorizontalSwipe = <T extends HTMLElement>(ref: RefObject<T> = null, options: UseSwipeOptions = defaultOptions) => {
   const opts: UseSwipeOptions = { ...defaultOptions, ...(options || {}), ...{ direction: 'horizontal' } }
 
   return useSwipe(ref, opts)

--- a/src/useMouse.ts
+++ b/src/useMouse.ts
@@ -1,4 +1,4 @@
-import { MutableRefObject } from 'react'
+import { RefObject } from 'react'
 import useMouseEvents, { MouseEventsMap } from './useMouseEvents'
 import useMouseState, { MouseStateSummary } from './useMouseState'
 
@@ -7,7 +7,7 @@ import useMouseState, { MouseStateSummary } from './useMouseState'
  * is the object of callback setters from the `useMouseEvents` hook.
  * It is intended as a shortcut to those hooks.
  */
-const useMouse = <T extends HTMLElement>(targetRef: MutableRefObject<T> = null): [MouseStateSummary, MouseEventsMap] => {
+const useMouse = <T extends HTMLElement>(targetRef: RefObject<T> = null): [MouseStateSummary, MouseEventsMap] => {
   const state = useMouseState(targetRef)
   const events = useMouseEvents(targetRef)
 

--- a/src/useMouseEvents.ts
+++ b/src/useMouseEvents.ts
@@ -1,4 +1,4 @@
-import { MutableRefObject } from 'react'
+import { RefObject } from 'react'
 import useHandlerSetterRef from './shared/useHandlerSetterRef'
 import createCbSetterErrorProxy from './shared/createCbSetterErrorProxy'
 import safeHasOwnProperty from './shared/safeHasOwnProperty'
@@ -31,7 +31,7 @@ export type MouseEventsMap = {
  * lose the React SyntheticEvent performance boost.<br />
  * If you were doing something like the following:
  */
-const useMouseEvents = <T extends HTMLElement>(targetRef: MutableRefObject<T> = null): MouseEventsMap => {
+const useMouseEvents = <T extends HTMLElement>(targetRef: RefObject<T> = null): MouseEventsMap => {
   const [onMouseDownHandler, setOnMouseDown] = useHandlerSetterRef<MouseEventCallback>()
   const [onMouseEnterHandler, setOnMouseEnter] = useHandlerSetterRef<MouseEventCallback>()
   const [onMouseLeaveHandler, setOnMouseLeave] = useHandlerSetterRef<MouseEventCallback>()

--- a/src/useMouseState.ts
+++ b/src/useMouseState.ts
@@ -1,4 +1,4 @@
-import { MutableRefObject, useState } from 'react'
+import { RefObject, useState } from 'react'
 import useMouseEvents from './useMouseEvents'
 
 export type MouseStateSummary = {
@@ -20,7 +20,7 @@ const createStateObject = (event: MouseEvent): MouseStateSummary => ({
  * It possibly accepts a DOM ref representing the mouse target.
  * If a target is not provided the state will be caught globally.
  */
-const useMouseState = <T extends HTMLElement>(targetRef: MutableRefObject<T> = null): MouseStateSummary => {
+const useMouseState = <T extends HTMLElement>(targetRef: RefObject<T> = null): MouseStateSummary => {
   const [state, setState] = useState<MouseStateSummary>({ clientX: 0, clientY: 0, screenX: 0, screenY: 0 })
   const { onMouseMove } = useMouseEvents(targetRef)
 

--- a/src/useResizeObserver.ts
+++ b/src/useResizeObserver.ts
@@ -1,4 +1,4 @@
-import { MutableRefObject, useEffect, useRef, useState } from 'react'
+import { RefObject, useEffect, useRef, useState } from 'react'
 import debounce from 'lodash.debounce'
 import isApiSupported from './shared/isAPISupported'
 import isClient from './shared/isClient'
@@ -14,9 +14,9 @@ export type DOMRectValues = Pick<DOMRectReadOnly, 'bottom' | 'height' | 'left' |
  * @param debounceTimeout
  * @returns {undefined}
  */
-const useResizeObserver = <T extends HTMLElement>(elementRef: MutableRefObject<T>, debounceTimeout: number = 100): DOMRectValues | undefined => {
+const useResizeObserver = <T extends HTMLElement>(elementRef: RefObject<T>, debounceTimeout: number = 100): DOMRectValues | undefined => {
   const isSupported = isApiSupported('ResizeObserver')
-  const observerRef = useRef<ResizeObserver>(null)
+  const observerRef = useRef<ResizeObserver | null>(null)
   const [DOMRect, setDOMRect] = useState<DOMRectValues>()
 
   if (isClient && !isSupported) {
@@ -37,7 +37,7 @@ const useResizeObserver = <T extends HTMLElement>(elementRef: MutableRefObject<T
 
       return () => {
         fn.cancel()
-        observerRef.current.disconnect()
+        observerRef.current?.disconnect()
       }
     }
 
@@ -48,7 +48,7 @@ const useResizeObserver = <T extends HTMLElement>(elementRef: MutableRefObject<T
   // observes on the provided element ref
   useEffect(() => {
     if (isSupported && elementRef.current) {
-      observerRef.current.observe(elementRef.current)
+      observerRef.current?.observe(elementRef.current)
     }
   }, [elementRef.current])
 

--- a/src/useSwipe.ts
+++ b/src/useSwipe.ts
@@ -1,4 +1,4 @@
-import { MutableRefObject, useRef, useState } from 'react'
+import { RefObject, useRef, useState } from 'react'
 import useMouseEvents from './useMouseEvents'
 import useTouchEvents from './useTouchEvents'
 import { Direction, getDirection, getHorizontalDirection, getPointerCoordinates, getVerticalDirection } from './shared/swipeUtils'
@@ -36,7 +36,7 @@ const isEqual = (prev: LocalSwipeState, next: LocalSwipeState): boolean => (
 /**
  * useSwipe hook
  */
-const useSwipe = <T extends HTMLElement>(targetRef: MutableRefObject<T> = null, options: UseSwipeOptions = defaultOptions) => {
+const useSwipe = <T extends HTMLElement>(targetRef: RefObject<T> = null, options: UseSwipeOptions = defaultOptions) => {
   const [state, setState] = useState(initialState)
   const startingPointRef = useRef<[number, number]>([-1, -1])
   const isDraggingRef = useRef(false)

--- a/src/useSwipeEvents.ts
+++ b/src/useSwipeEvents.ts
@@ -1,4 +1,4 @@
-import { MutableRefObject, useEffect, useRef, useState } from 'react'
+import { RefObject, useEffect, useRef, useState } from 'react'
 import useHandlerSetterRef from './shared/useHandlerSetterRef'
 import useMouseEvents from './useMouseEvents'
 import useTouchEvents from './useTouchEvents'
@@ -28,7 +28,7 @@ const defaultOptions: UseEventsSwipeOptions = {
  * Very similar to useSwipe but doesn't cause re-rendering during swipe
  */
 const useSilentSwipeState = <T extends HTMLElement>(
-  targetRef: MutableRefObject<T> = null,
+  targetRef: RefObject<T> = null,
   options: UseEventsSwipeOptions = defaultOptions,
   onSwipeStart: (...args: any[]) => any,
   onSwipeMove: (...args: any[]) => any,
@@ -133,7 +133,7 @@ const useSilentSwipeState = <T extends HTMLElement>(
  * @param targetRef
  * @param options
  */
-const useSwipeEvents = <T extends HTMLElement>(targetRef: MutableRefObject<T> = null, options: UseEventsSwipeOptions = defaultOptions) => {
+const useSwipeEvents = <T extends HTMLElement>(targetRef: RefObject<T> = null, options: UseEventsSwipeOptions = defaultOptions) => {
   const opts = { ...defaultOptions, ...(options || {}) }
   const [onSwipeLeft, setOnSwipeLeft] = useHandlerSetterRef<SwipeCallback>()
   const [onSwipeRight, setOnSwipeRight] = useHandlerSetterRef<SwipeCallback>()

--- a/src/useTouch.ts
+++ b/src/useTouch.ts
@@ -1,4 +1,4 @@
-import { MutableRefObject } from 'react'
+import { RefObject } from 'react'
 import useTouchEvents, { TouchEventsMap } from './useTouchEvents'
 import useTouchState, { TouchState } from './useTouchState'
 
@@ -7,7 +7,7 @@ import useTouchState, { TouchState } from './useTouchState'
  * is the object of callback setters from the `useTouchEvents` hook.
  * It is intended as a shortcut to those hooks.
  */
-const useTouch = <T extends HTMLElement>(targetRef: MutableRefObject<T> = null): [TouchState, TouchEventsMap] => {
+const useTouch = <T extends HTMLElement>(targetRef: RefObject<T> = null): [TouchState, TouchEventsMap] => {
   const state = useTouchState(targetRef)
   const events = useTouchEvents(targetRef)
 

--- a/src/useTouchEvents.ts
+++ b/src/useTouchEvents.ts
@@ -1,4 +1,4 @@
-import { MutableRefObject } from 'react'
+import { RefObject } from 'react'
 import useHandlerSetterRef from './shared/useHandlerSetterRef'
 import createCbSetterErrorProxy from './shared/createCbSetterErrorProxy'
 import safeHasOwnProperty from './shared/safeHasOwnProperty'
@@ -29,7 +29,7 @@ export type TouchEventsMap = {
  * If you were doing something like the following:
  *
  */
-const useTouchEvents = <T extends HTMLElement>(targetRef: MutableRefObject<T> = null): TouchEventsMap => {
+const useTouchEvents = <T extends HTMLElement>(targetRef: RefObject<T> = null): TouchEventsMap => {
   const [onTouchStartHandler, setOnTouchStartHandler] = useHandlerSetterRef<TouchCallback>()
   const [onTouchEndHandler, setOnTouchEndHandler] = useHandlerSetterRef<TouchCallback>()
   const [onTouchCancelHandler, setOnTouchCancelHandler] = useHandlerSetterRef<TouchCallback>()

--- a/src/useTouchState.ts
+++ b/src/useTouchState.ts
@@ -1,4 +1,4 @@
-import { MutableRefObject, useState } from 'react'
+import { RefObject, useState } from 'react'
 import useTouchEvents from './useTouchEvents'
 
 export type TouchState = TouchList | { length: 0 }
@@ -8,7 +8,7 @@ export type TouchState = TouchList | { length: 0 }
  * It possibly accepts a DOM ref representing the mouse target.
  * If a target is not provided the state will be caught globally.
  */
-const useTouchState = <T extends HTMLElement>(targetRef: MutableRefObject<T> = null): TouchState => {
+const useTouchState = <T extends HTMLElement>(targetRef: RefObject<T> = null): TouchState => {
   const [state, setState] = useState<TouchState>({ length: 0 })
   const { onTouchMove } = useTouchEvents(targetRef)
 

--- a/src/useVerticalSwipe.ts
+++ b/src/useVerticalSwipe.ts
@@ -1,4 +1,4 @@
-import { MutableRefObject } from 'react'
+import { RefObject } from 'react'
 import useSwipe, { UseSwipeOptions } from './useSwipe'
 
 const defaultOptions: UseSwipeOptions = {
@@ -12,7 +12,7 @@ const defaultOptions: UseSwipeOptions = {
  * @param options
  * @return {{alpha: number, count: number, swiping: boolean, direction: null}}
  */
-const useVerticalSwipe = <T extends HTMLElement>(ref: MutableRefObject<T> = null, options: UseSwipeOptions = defaultOptions) => {
+const useVerticalSwipe = <T extends HTMLElement>(ref: RefObject<T> = null, options: UseSwipeOptions = defaultOptions) => {
   const opts: UseSwipeOptions = { ...defaultOptions, ...(options || {}), ...{ direction: 'vertical' } }
 
   return useSwipe(ref, opts)

--- a/src/useViewportSpy.ts
+++ b/src/useViewportSpy.ts
@@ -1,4 +1,4 @@
-import { MutableRefObject, useLayoutEffect, useState } from 'react'
+import { RefObject, useLayoutEffect, useState } from 'react'
 import isClient from './shared/isClient'
 import isApiSupported from './shared/isAPISupported'
 import isDevelopment from './shared/isDevelopment'
@@ -17,7 +17,7 @@ const errorMessage = 'IntersectionObserver is not supported, this could happen b
  * Uses the IntersectionObserverMock API to tell whether the given DOM Element (from useRef) is visible within the
  * viewport.
  */
-const useViewportSpy = <T extends HTMLElement>(elementRef: MutableRefObject<T>, options: IntersectionObserverInit = defaultOptions) => {
+const useViewportSpy = <T extends HTMLElement>(elementRef: RefObject<T>, options: IntersectionObserverInit = defaultOptions) => {
   if (!isClient || !isApiSupported('IntersectionObserver')) {
     if (isDevelopment) {
       // eslint-disable-next-line no-console

--- a/test/useResizeObserver.spec.js
+++ b/test/useResizeObserver.spec.js
@@ -1,4 +1,5 @@
 import { act, cleanup, renderHook } from '@testing-library/react-hooks'
+import { expect } from 'chai'
 import useResizeObserver from '../dist/useResizeObserver'
 import ResizeObserverMock from './mocks/ResizeObserver.mock'
 import promiseDelay from './utils/promiseDelay'
@@ -40,5 +41,27 @@ describe('useResizeObserver', () => {
     await promiseDelay(250) // wait 250ms to let the debounced fn to perform
 
     expect(result.current).to.be.an('object')
+  })
+
+  describe('When the API is not supported', () => {
+    beforeEach(() => {
+      delete global.ResizeObserver
+      delete window.ResizeObserver
+    })
+  
+    afterEach(() => {
+      global.ResizeObserver = window.ResizeObserver = originalRO
+      sinon.restore()
+    })
+    
+    it('should not observe anything', async () => {
+      const refMock = { current: document.createElement('div') }
+      const warnSpy = sinon.spy(console, 'warn');
+     
+      const {result} = renderHook(() => useResizeObserver(refMock))
+
+      expect(warnSpy.called).to.be.true
+      expect(result.current).to.be.undefined
+    })
   })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Related to #327, this PR fixes the types for all hooks the originally advertised using a `MutableRefObject`, when the expectation was that they would be React-managed refs, which should be a read-only ref, or `RefObject`. There are a couple places where I left MutableRefObject, because they were still appropriate uses of that type.

## Related Issue
Fixes #327 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran verification, locally installed in my TS project to verify types are being reported correctly.

