### PR TITLE
add error handling to use storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -810,3 +810,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - introduces `useViewportState`
+
+## [3.1.1] - 2022-06-23
+
+### Added
+
+- error handling for useStorage hook

--- a/src/factory/createStorageHook.ts
+++ b/src/factory/createStorageHook.ts
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useState } from 'react'
+import { useState } from 'react'
 import safelyParseJson from '../shared/safelyParseJson'
 import isClient from '../shared/isClient'
 import isAPISupported from '../shared/isAPISupported'
@@ -9,6 +9,7 @@ import noop from '../shared/noop'
  * An utility to quickly create hooks to access both Session Storage and Local Storage
  */
 const createStorageHook = (type: 'session' | 'local') => {
+  type SetValue<TValue> = (value: TValue | ((previousValue: TValue) => TValue)) => void
   const storageName = `${type}Storage`
 
   if (isClient && !isAPISupported(storageName)) {
@@ -19,7 +20,10 @@ const createStorageHook = (type: 'session' | 'local') => {
   /**
    * the hook
    */
-  return function useStorageCreatedHook<TValue>(storageKey: string, defaultValue?: any): [TValue, Dispatch<SetStateAction<TValue>>] {
+  return function useStorageCreatedHook<TValue>(
+    storageKey: string,
+    defaultValue?: any,
+  ): [TValue, SetValue<TValue>] {
     if (!isClient) {
       if (isDevelopment) {
         // eslint-disable-next-line no-console
@@ -39,7 +43,7 @@ const createStorageHook = (type: 'session' | 'local') => {
       },
     )
 
-    const setValue = (value: TValue | ((previousValue: TValue) => TValue)) => {
+    const setValue: SetValue<TValue> = (value) => {
       try {
         const valueToStore = value instanceof Function ? value(storedValue) : value
         storage.setItem(storageKey, JSON.stringify(valueToStore))

--- a/test/useLocalStorage.spec.js
+++ b/test/useLocalStorage.spec.js
@@ -55,4 +55,45 @@ describe('useLocalStorage', () => {
 
     expect(container.querySelector('p').innerHTML).to.equal('200')
   })
+
+  it('should gracefully handle a getItem error and use the default value', () => {
+    Object.defineProperty(window, "localStorage", {
+      value: {
+        ...window.localStorage,
+        getItem: () => {
+          throw new Error()
+        },
+      },
+    })
+
+    const { result, rerender } = renderHook(() =>
+      useLocalStorage("storageKey_3", 100)
+    )
+    const [value] = result.current
+
+    rerender()
+
+    expect(value).to.equal(100)
+  })
+
+  it("should gracefully handle a setItem error and maintain the current value", () => {
+    Object.defineProperty(window, "localStorage", {
+      value: {
+        ...window.localStorage,
+        setItem: () => {
+          throw new Error()
+        },
+      },
+    })
+
+    const { result, rerender } = renderHook(() =>
+      useLocalStorage("storageKey_4", 100)
+    )
+    const [value, setValue] = result.current
+    setValue(200)
+
+    rerender()
+
+    expect(value).to.equal(100)
+  })
 })

--- a/test/useSessionStorage.spec.js
+++ b/test/useSessionStorage.spec.js
@@ -55,4 +55,45 @@ describe('useSessionStorage', () => {
 
     expect(container.querySelector('p').innerHTML).to.equal('200')
   })
+
+  it('should gracefully handle a getItem error and use the default value', () => {
+    Object.defineProperty(window, "sessionStorage", {
+      value: {
+        ...window.sessionStorage,
+        getItem: () => {
+          throw new Error()
+        },
+      },
+    })
+
+    const { result, rerender } = renderHook(() =>
+      useSessionStorage("storageKey_3", 100)
+    )
+    const [value] = result.current
+
+    rerender()
+
+    expect(value).to.equal(100)
+  })
+
+  it("should gracefully handle a setItem error and maintain the current value", () => {
+    Object.defineProperty(window, "sessionStorage", {
+      value: {
+        ...window.sessionStorage,
+        setItem: () => {
+          throw new Error()
+        },
+      },
+    })
+
+    const { result, rerender } = renderHook(() =>
+      useSessionStorage("storageKey_4", 100)
+    )
+    const [value, setValue] = result.current
+    setValue(200)
+
+    rerender()
+
+    expect(value).to.equal(100)
+  })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add error handling to the `useStorage` hooks
## Description
<!--- Describe your changes in detail -->
Examples of possible errors include `QuotaExceededError` errors if the storage runs out of space, or security related errors if the user disables access to the browser storage. Currently, these errors are unhandled by the `useStorage` hooks. 

I removed the `useEffect` so the `storedValue` state would only be set if the set browser storage call was successful. 
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I've personally encountered `QuotaExceededError` errors resulting from the `useStorage` hooks' lack of error handling.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added test cases for `setItem` and `getItem` errors to `useLocalStorage.spec.js` and `useSessionStorage.spec.js`
## Screenshots (if appropriate):
