### PR TITLE
add fix to set browser storage on initial render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -896,3 +896,9 @@ Errored release
 ### Fixes
 
 - error handling for useStorage hook
+
+## [3.5.2] - 2022-06-24
+
+### Fixes
+
+- add more types for useStorage hook, fix bug where storage wasn't being set on initial render

--- a/src/factory/createStorageHook.ts
+++ b/src/factory/createStorageHook.ts
@@ -44,7 +44,7 @@ const createStorageHook = (type: 'session' | 'local') => {
       () => {
         let valueToStore: string
         try {
-          valueToStore = storage.getItem(storageKey) ?? JSON.stringify(defaultValue)
+          valueToStore = storage.getItem(storageKey) || JSON.stringify(defaultValue)
         } catch (e) {
           valueToStore = JSON.stringify(defaultValue)
         }

--- a/src/factory/createStorageHook.ts
+++ b/src/factory/createStorageHook.ts
@@ -10,7 +10,7 @@ import noop from '../shared/noop'
  */
 const createStorageHook = (type: 'session' | 'local') => {
   type SetValue<TValue> = (value: TValue | ((previousValue: TValue) => TValue)) => void
-  const storageName = `${type}Storage`
+  const storageName: `${typeof type}Storage` = `${type}Storage`
 
   if (isClient && !isAPISupported(storageName)) {
     // eslint-disable-next-line no-console
@@ -31,25 +31,33 @@ const createStorageHook = (type: 'session' | 'local') => {
       }
       return [JSON.stringify(defaultValue) as unknown as TValue, noop]
     }
+    const storage = (window)[storageName]
 
-    const storage = (window as any)[storageName]
+    const safelySetStorage = (valueToStore: string) => {
+      try {
+        storage.setItem(storageKey, valueToStore)
+        // eslint-disable-next-line no-empty
+      } catch (e) {}
+    }
+
     const [storedValue, setStoredValue] = useState<TValue>(
       () => {
+        let valueToStore: string
         try {
-          return safelyParseJson(storage.getItem(storageKey) || JSON.stringify(defaultValue))
+          valueToStore = storage.getItem(storageKey) ?? JSON.stringify(defaultValue)
         } catch (e) {
-          return safelyParseJson(JSON.stringify(defaultValue))
+          valueToStore = JSON.stringify(defaultValue)
         }
+
+        safelySetStorage(valueToStore)
+        return safelyParseJson(valueToStore)
       },
     )
 
     const setValue: SetValue<TValue> = (value) => {
-      try {
-        const valueToStore = value instanceof Function ? value(storedValue) : value
-        storage.setItem(storageKey, JSON.stringify(valueToStore))
-        setStoredValue(valueToStore)
-      // eslint-disable-next-line no-empty
-      } catch (error) {}
+      const valueToStore = value instanceof Function ? value(storedValue) : value
+      safelySetStorage(JSON.stringify(valueToStore))
+      setStoredValue(valueToStore)
     }
 
     return [storedValue, setValue]

--- a/test/useLocalStorage.spec.js
+++ b/test/useLocalStorage.spec.js
@@ -1,6 +1,6 @@
-import React, { useEffect } from 'react'
-import { cleanup as cleanupReact, render } from '@testing-library/react'
+import { cleanup as cleanupReact } from '@testing-library/react'
 import { cleanup as cleanupHooks, renderHook } from '@testing-library/react-hooks'
+import { act } from 'react-dom/test-utils'
 import useLocalStorage from '../dist/useLocalStorage'
 import assertHook from './utils/assertHook'
 
@@ -17,44 +17,51 @@ describe('useLocalStorage', () => {
   assertHook(useLocalStorage)
 
   it('should return null when no default value defined', () => {
-    const { result, rerender } = renderHook(() => useLocalStorage('storageKey_1'))
+    const { result } = renderHook(() => useLocalStorage('storageKey_1'))
     const [value] = result.current
-
-    rerender()
 
     expect(value).to.equal(null)
   })
 
   it('should return default value', () => {
-    const { result, rerender } = renderHook(() => useLocalStorage('storageKey_2', 100))
+    const { result } = renderHook(() => useLocalStorage('storageKey_2', 100))
     const [value] = result.current
 
-    rerender()
-
     expect(value).to.equal(100)
+    expect(JSON.parse(window.localStorage.getItem('storageKey_2'))).to.equal(100)
   })
 
   it('should store and return new values', () => {
-    const TestComponent = (props) => {
-      // eslint-disable-next-line react/prop-types
-      const { newValue } = props
-      const [value, setValue] = useLocalStorage('storageKey_2', 100)
+    const { result } = renderHook(() =>
+      useLocalStorage("storageKey_3", 100)
+    )
 
-      const setNewState = (v) => {
-        setValue(v)
-      }
+    expect(result.current[0]).to.equal(100)
+    expect(JSON.parse(window.localStorage.getItem('storageKey_3'))).to.equal(100)
 
-      useEffect(() => {
-        setNewState(newValue)
-      }, [])
+    act(() => {
+      result.current[1](200)
+    })
 
-      return <p>{value}</p>
-    }
-
-    const { container } = render(<TestComponent newValue={200} />)
-
-    expect(container.querySelector('p').innerHTML).to.equal('200')
+    expect(result.current[0]).to.equal(200)
+    expect(JSON.parse(window.localStorage.getItem('storageKey_3'))).to.equal(200)
   })
+
+  it('should accept a callback argument for setValue', () => {
+    const { result } = renderHook(() =>
+      useLocalStorage("storageKey_4", 100)
+    )
+
+    expect(result.current[0]).to.equal(100)
+    expect(JSON.parse(window.localStorage.getItem('storageKey_4'))).to.equal(100)
+
+    act(() => {
+      result.current[1](prev => prev + 100)
+    })
+
+    expect(result.current[0]).to.equal(200)
+    expect(JSON.parse(window.localStorage.getItem('storageKey_4'))).to.equal(200)
+  });
 
   it('should gracefully handle a getItem error and use the default value', () => {
     Object.defineProperty(window, "localStorage", {
@@ -66,17 +73,15 @@ describe('useLocalStorage', () => {
       },
     })
 
-    const { result, rerender } = renderHook(() =>
-      useLocalStorage("storageKey_3", 100)
+    const { result } = renderHook(() =>
+      useLocalStorage("storageKey_5", 100)
     )
     const [value] = result.current
-
-    rerender()
 
     expect(value).to.equal(100)
   })
 
-  it("should gracefully handle a setItem error and maintain the current value", () => {
+  it("should gracefully handle a setItem error and set the new value", () => {
     Object.defineProperty(window, "localStorage", {
       value: {
         ...window.localStorage,
@@ -86,14 +91,14 @@ describe('useLocalStorage', () => {
       },
     })
 
-    const { result, rerender } = renderHook(() =>
-      useLocalStorage("storageKey_4", 100)
+    const { result } = renderHook(() =>
+      useLocalStorage("storageKey_6", 100)
     )
-    const [value, setValue] = result.current
-    setValue(200)
 
-    rerender()
+    act(() => {
+      result.current[1](200)
+    })
 
-    expect(value).to.equal(100)
+    expect(result.current[0]).to.equal(200)
   })
 })


### PR DESCRIPTION
Add fix to set browser storage on initial render
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In my previous change (https://github.com/antonioru/beautiful-react-hooks/pull/367) I removed the `useEffect` which in turn caused the browser storage not to be set on the initial render; this pr fixes that bug. 

I also added an update so that when `storage.setItem` throws an error in a `setValue` call, the `storedValue` state will still be set (previously the new state was not set). This is consistent with the behavior before https://github.com/antonioru/beautiful-react-hooks/pull/367, and with other similar `useStorage` hooks i.e. [UI.dev's hook](https://usehooks.com/useLocalStorage/)

I updated the types so the `storage` variable is correctly typed as `Storage`, which adds more type safety to the `storage.setItem` and `storage.getItem` calls. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/antonioru/beautiful-react-hooks/pull/367/

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I added tests to `useLocalStorage.spec.js` and `useSessionStorage.spec.js` that directly check the browser storage to ensure it's always up to date with the state. I also removed unnecessary `rerender` calls, and added `act`s per the [official docs](https://react-hooks-testing-library.com/usage/basic-hooks#updates)

## Screenshots (if appropriate):
