### PR TITLE
wrap setValue from useStorage hook in useCallback to persist reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -897,3 +897,9 @@ Errored release
 
 - error handling for useStorage hook
 - add more types for useStorage hook, fix bug where storage wasn't being set on initial render
+
+## [3.5.2] - 2022-06-27
+
+### Fixes
+
+- wrap setValue from useStorage hook in useCallback to persist reference

--- a/src/factory/createStorageHook.ts
+++ b/src/factory/createStorageHook.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import safelyParseJson from '../shared/safelyParseJson'
 import isClient from '../shared/isClient'
 import isAPISupported from '../shared/isAPISupported'
@@ -33,12 +33,12 @@ const createStorageHook = (type: 'session' | 'local') => {
     }
     const storage = (window)[storageName]
 
-    const safelySetStorage = (valueToStore: string) => {
+    const safelySetStorage = useCallback((valueToStore: string) => {
       try {
         storage.setItem(storageKey, valueToStore)
         // eslint-disable-next-line no-empty
       } catch (e) {}
-    }
+    }, [storage, storageKey])
 
     const [storedValue, setStoredValue] = useState<TValue>(
       () => {
@@ -54,11 +54,11 @@ const createStorageHook = (type: 'session' | 'local') => {
       },
     )
 
-    const setValue: SetValue<TValue> = (value) => {
+    const setValue: SetValue<TValue> = useCallback((value) => {
       const valueToStore = value instanceof Function ? value(storedValue) : value
       safelySetStorage(JSON.stringify(valueToStore))
       setStoredValue(valueToStore)
-    }
+    }, [safelySetStorage, storedValue])
 
     return [storedValue, setValue]
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Wrap `setValue` from `useStorage` hook in `useCallback` to persist reference

## Description
<!--- Describe your changes in detail -->
This allows `setValue` to be added to a dependency array

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
