### PR TITLE
fix: useMediaQuery hook warning in next.js

### DIFF
--- a/src/useMediaQuery.ts
+++ b/src/useMediaQuery.ts
@@ -20,7 +20,7 @@ const useMediaQuery = (mediaQuery: string) => {
     return false
   }
 
-  const [isVerified, setIsVerified] = useState(!!window.matchMedia(mediaQuery).matches)
+  const [isVerified, setIsVerified] = useState(false)
 
   useEffect(() => {
     const mediaQueryList = window.matchMedia(mediaQuery)
@@ -34,6 +34,7 @@ const useMediaQuery = (mediaQuery: string) => {
     }
 
     documentChangeHandler()
+
     return () => {
       try {
         mediaQueryList.removeEventListener('change', documentChangeHandler)
@@ -42,7 +43,7 @@ const useMediaQuery = (mediaQuery: string) => {
         mediaQueryList.removeListener(documentChangeHandler)
       }
     }
-  }, [mediaQuery])
+  }, [])
 
   return isVerified
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Default useState value is now set to false and then is updated in the useEffect hook + useEffect hook now runs only on mount

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#316

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#316

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. tests pass
2. behavior in docs example still works properly

## Screenshots (if appropriate):
none