### PR TITLE
feat(hook): create useDarkMode hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ $ yarn add beautiful-react-hooks
 * [useSwipeEvents](docs/useSwipeEvents.md)
 * [useConditionalTimeout](docs/useConditionalTimeout.md)
 * [useCookie](docs/useCookie.md)
+* [useDarkMode](docs/useDarkMode.md)
+* [useUpdateEffect](docs/useUpdateEffect.md)
+* [useIsFirstRender](docs/useIsFirstRender.md)
 
 <div>
   <p align="center">

--- a/docs/README.es-ES.md
+++ b/docs/README.es-ES.md
@@ -112,6 +112,9 @@ $ yarn add beautiful-react-hooks
 * [useSwipeEvents](useSwipeEvents.md)
 * [useConditionalTimeout](useConditionalTimeout.md)
 * [useCookie](useCookie.md)
+* [useDarkMode](useDarkMode.md)
+* [useUpdateEffect](useUpdateEffect.md)
+* [useIsFirstRender](useIsFirstRender.md)
 
 <div>
   <p align="center">

--- a/docs/README.it-IT.md
+++ b/docs/README.it-IT.md
@@ -112,6 +112,9 @@ $ yarn add beautiful-react-hooks
 * [useSwipeEvents](useSwipeEvents.md)
 * [useConditionalTimeout](useConditionalTimeout.md)
 * [useCookie](useCookie.md)
+* [useDarkMode](useDarkMode.md)
+* [useUpdateEffect](useUpdateEffect.md)
+* [useIsFirstRender](useIsFirstRender.md)
 
 <div>
   <p align="center">

--- a/docs/README.jp-JP.md
+++ b/docs/README.jp-JP.md
@@ -112,6 +112,9 @@ $ yarn add beautiful-react-hooks
 * [useSwipeEvents](useSwipeEvents.md)
 * [useConditionalTimeout](useConditionalTimeout.md)
 * [useCookie](useCookie.md)
+* [useDarkMode](useDarkMode.md)
+* [useUpdateEffect](useUpdateEffect.md)
+* [useIsFirstRender](useIsFirstRender.md)
 
 <div>
   <p align="center">

--- a/docs/README.pl-PL.md
+++ b/docs/README.pl-PL.md
@@ -115,6 +115,9 @@ $ yarn add beautiful-react-hooks
 * [useSwipeEvents](useSwipeEvents.md)
 * [useConditionalTimeout](useConditionalTimeout.md)
 * [useCookie](useCookie.md)
+* [useDarkMode](useDarkMode.md)
+* [useUpdateEffect](useUpdateEffect.md)
+* [useIsFirstRender](useIsFirstRender.md)
 
 <div>
   <p align="center">

--- a/docs/README.pt-BR.md
+++ b/docs/README.pt-BR.md
@@ -114,6 +114,9 @@ $ yarn add beautiful-react-hooks
 * [useSwipeEvents](useSwipeEvents.md)
 * [useConditionalTimeout](useConditionalTimeout.md)
 * [useCookie](useCookie.md)
+* [useDarkMode](useDarkMode.md)
+* [useUpdateEffect](useUpdateEffect.md)
+* [useIsFirstRender](useIsFirstRender.md)
 
 <div>
   <p align="center">

--- a/docs/README.uk-UA.md
+++ b/docs/README.uk-UA.md
@@ -113,6 +113,9 @@ $ yarn add beautiful-react-hooks
 * [useSwipeEvents](useSwipeEvents.md)
 * [useConditionalTimeout](useConditionalTimeout.md)
 * [useCookie](useCookie.md)
+* [useDarkMode](useDarkMode.md)
+* [useUpdateEffect](useUpdateEffect.md)
+* [useIsFirstRender](useIsFirstRender.md)
 
 <div>
   <p align="center">

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -110,6 +110,9 @@ $ yarn add beautiful-react-hooks
 * [useSwipeEvents](useSwipeEvents.md)
 * [useConditionalTimeout](useConditionalTimeout.md)
 * [useCookie](useCookie.md)
+* [useDarkMode](useDarkMode.md)
+* [useUpdateEffect](useUpdateEffect.md)
+* [useIsFirstRender](useIsFirstRender.md)
 
 <div>
   <p align="center">

--- a/docs/useDarkMode.md
+++ b/docs/useDarkMode.md
@@ -1,0 +1,57 @@
+# useDarkMode
+
+-- This hook handle all logic required to add a ☾ dark mode toggle to your website --
+
+### 💡 Why?
+
+- SSR safe,
+- Keep information about dark mode in local storage
+- Return a few functions allows you to change dark mode state
+- Read information about dark mode from user's operating system `prefers-color-scheme`
+
+### Basic Usage:
+
+```jsx harmony
+import { Pill, Paragraph, Icon } from 'beautiful-react-ui';
+import useDarkMode from 'beautiful-react-hooks/useDarkMode'; 
+
+const UseDarkModeExample = () => {
+  const { 
+    toggle,
+    enable,
+    disable,
+    isDarkMode
+  } = useDarkMode();
+  
+  return (
+    <DisplayDemo>
+      <Paragraph>Click on the buttons to update isDarkMode flag</Paragraph>
+      <Paragraph>isDarkMode: {isDarkMode ? 'true' : 'false'}</Paragraph>
+      <Pill color='primary' onClick={enable}>
+        <Icon name="envelope" />
+        Enable dark mode
+      </Pill>
+      <Pill color='primary' onClick={disable}>
+        <Icon name="envelope" />
+        Disable dark mode
+      </Pill>
+      <Pill color='primary' onClick={toggle}>
+        <Icon name="envelope" />
+        Toggle dark mode
+      </Pill>
+    </DisplayDemo>
+  );
+};
+
+<UseDarkModeExample />
+```
+
+### Mastering the hooks
+
+#### ✅ When to use
+ 
+- When you need to handle dark/light mode logic in your app,
+
+#### 🛑 When not to use
+
+- This hook does not support SSR,

--- a/docs/useIsFirstRender.md
+++ b/docs/useIsFirstRender.md
@@ -1,0 +1,41 @@
+# useIsFirstRender
+
+-- This hook return a boolean set to true at the mount time and then always false --
+
+### 💡 Why?
+
+- Give information about if it's first render
+
+### Basic Usage:
+
+```jsx harmony
+import { useState, useCallback } from 'react';
+import { Pill, Paragraph, Icon } from 'beautiful-react-ui';
+import useIsFirstRender from 'beautiful-react-hooks/useIsFirstRender'; 
+
+const UseIsFirstRenderExample = () => {
+  const [data, setData] = useState(0)
+  const isFirstRender = useIsFirstRender();
+
+  const setNewDate = useCallback(() => setData(Date.now()), []);
+
+  return (
+    <DisplayDemo>
+      <Paragraph>Click on the button to update isFirstRender flag</Paragraph>
+      <Paragraph>isFirstRender: {isFirstRender ? 'yes' : 'no'}</Paragraph>
+      <Pill color='primary' onClick={setNewDate}>
+        <Icon name="envelope" />
+        Update data
+      </Pill>
+    </DisplayDemo>
+  );
+};
+
+<UseIsFirstRenderExample />
+```
+
+### Mastering the hooks
+
+#### ✅ When to use
+ 
+- When you need to get information if first render occurs

--- a/docs/useUpdateEffect.md
+++ b/docs/useUpdateEffect.md
@@ -1,0 +1,47 @@
+# useUpdateEffect
+
+-- This hook is a modification to `useEffect` hook that is skipping the first render --
+
+### 💡 Why?
+
+- Sometimes you do not want to run useEffect on the first render and this hook allows you to do this
+
+### Basic Usage:
+
+```jsx harmony
+import { useState, useEffect, useCallback } from 'react';
+import { Pill, Paragraph, Icon } from 'beautiful-react-ui';
+import useUpdateEffect from 'beautiful-react-hooks/useUpdateEffect'; 
+
+const UseUpdateEffectExample = () => {
+  const [data, setData] = useState(0)
+
+  useEffect(() => {
+    console.log('Normal useEffect', { data })
+  }, [data])
+
+  useUpdateEffect(() => {
+    console.log('Update useEffect only', { data })
+  }, [data])
+
+  const setNewDate = useCallback(() => setData(Date.now()), []);
+
+  return (
+    <DisplayDemo>
+      <Paragraph>Open a console to see result and try to click update date button</Paragraph>
+      <Pill color='primary' onClick={setNewDate}>
+        <Icon name="envelope" />
+        Update data
+      </Pill>
+    </DisplayDemo>
+  );
+};
+
+<UseUpdateEffectExample />
+```
+
+### Mastering the hooks
+
+#### ✅ When to use
+ 
+- When you want to skip first render of useEffect

--- a/src/useDarkMode.ts
+++ b/src/useDarkMode.ts
@@ -1,0 +1,58 @@
+import { useCallback } from 'react'
+
+import useMediaQuery from './useMediaQuery'
+import useUpdateEffect from './useUpdateEffect'
+import useLocalStorage from './useLocalStorage'
+
+import noop from './shared/noop'
+import isClient from './shared/isClient'
+import isDevelopment from './shared/isDevelopment'
+
+const COLOR_SCHEME_QUERY = '(prefers-color-scheme: dark)'
+export const LOCAL_STORAGE_KEY = 'beautiful-react-hooks-is-dark-mode'
+
+const useDarkMode = (
+  defaultValue?: boolean,
+  localStorageKey: string = LOCAL_STORAGE_KEY,
+) => {
+  if (!isClient) {
+    if (!isDevelopment) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'Please be aware that useDarkMode hook could not be available during SSR',
+      )
+    }
+
+    return Object.freeze({
+      toggle: noop,
+      enable: noop,
+      disable: noop,
+      isDarkMode: defaultValue ?? false,
+    })
+  }
+
+  const isDarkOS = useMediaQuery(COLOR_SCHEME_QUERY)
+  const [isDarkMode, setIsDarkMode] = useLocalStorage<boolean>(
+    localStorageKey,
+    defaultValue ?? isDarkOS ?? false,
+  )
+
+  useUpdateEffect(() => {
+    setIsDarkMode(isDarkOS)
+  }, [isDarkOS])
+
+  const enable = useCallback(() => setIsDarkMode(true), [])
+
+  const disable = useCallback(() => setIsDarkMode(false), [])
+
+  const toggle = useCallback(() => setIsDarkMode((prev) => !prev), [setIsDarkMode])
+
+  return Object.freeze({
+    toggle,
+    enable,
+    disable,
+    isDarkMode,
+  })
+}
+
+export default useDarkMode

--- a/src/useIsFirstRender.ts
+++ b/src/useIsFirstRender.ts
@@ -1,0 +1,15 @@
+import { useRef } from 'react'
+
+const useIsFirstRender = () => {
+  const isFirstRenderRef = useRef(true)
+
+  if (isFirstRenderRef.current) {
+    isFirstRenderRef.current = false
+
+    return true
+  }
+
+  return isFirstRenderRef.current
+}
+
+export default useIsFirstRender

--- a/src/useUpdateEffect.ts
+++ b/src/useUpdateEffect.ts
@@ -1,0 +1,16 @@
+import { DependencyList, EffectCallback, useEffect } from 'react'
+
+import useIsFirstRender from './useIsFirstRender'
+
+function useUpdateEffect(callback: EffectCallback, deps?: DependencyList) {
+  const isFirstRender = useIsFirstRender()
+
+  // eslint-disable-next-line consistent-return
+  useEffect(() => {
+    if (!isFirstRender) {
+      return callback()
+    }
+  }, deps)
+}
+
+export default useUpdateEffect

--- a/test/mocks/MatchMediaQueryList.mock.js
+++ b/test/mocks/MatchMediaQueryList.mock.js
@@ -1,0 +1,12 @@
+const mediaQueryListMock = {
+  listeners: {},
+  matches: true,
+  addEventListener(cb) {
+    this.listeners.cb = cb
+  },
+  removeListener() {
+    delete this.listeners.cb
+  }
+}
+
+export default mediaQueryListMock;

--- a/test/mocks/MatchMediaQueryList.mock.js
+++ b/test/mocks/MatchMediaQueryList.mock.js
@@ -1,4 +1,4 @@
-const mediaQueryListMock = {
+const matchMediaQueryListMock = {
   listeners: {},
   matches: true,
   addEventListener(cb) {
@@ -9,4 +9,4 @@ const mediaQueryListMock = {
   }
 }
 
-export default mediaQueryListMock;
+export default matchMediaQueryListMock;

--- a/test/useDarkMode.spec.js
+++ b/test/useDarkMode.spec.js
@@ -2,20 +2,16 @@ import { cleanup, renderHook } from '@testing-library/react-hooks'
 
 import assertHook from './utils/assertHook'
 import useDarkMode from '../dist/useDarkMode'
-import mediaQueryListMock from './mocks/MatchMediaQueryList.mock'
+import matchMediaQueryListMock from './mocks/MatchMediaQueryList.mock'
 
-const consoleWarnSpy = sinon.spy()
-const realConsoleWarning = console.warn
 const realMatchMedia = window.matchMedia
 
 describe('useDarkMode', () => {
   before(() => {
-    console.warn = consoleWarnSpy
-    window.matchMedia = () => mediaQueryListMock
+    window.matchMedia = () => matchMediaQueryListMock
   })
 
   after(() => {
-    console.warn = realConsoleWarning
     window.matchMedia = realMatchMedia
   })
 
@@ -36,18 +32,18 @@ describe('useDarkMode', () => {
   });
 
   it('should set the dark mode to false when the media query does not match', () => {
-    const updatedMediaQueryListMock = {
-      ...mediaQueryListMock,
+    const updatedMatchMediaQueryListMock = {
+      ...matchMediaQueryListMock,
       matches: false
     }
 
-    window.matchMedia = () => updatedMediaQueryListMock
+    window.matchMedia = () => updatedMatchMediaQueryListMock
 
     const { result } = renderHook(() => useDarkMode())
 
     expect(result.current.isDarkMode).to.be.true
 
-    window.matchMedia = () => mediaQueryListMock
+    window.matchMedia = () => matchMediaQueryListMock
   });
 
   it('should save dark mode to local storage', () => {

--- a/test/useDarkMode.spec.js
+++ b/test/useDarkMode.spec.js
@@ -1,0 +1,89 @@
+import { cleanup, renderHook } from '@testing-library/react-hooks'
+
+import assertHook from './utils/assertHook'
+import useDarkMode from '../dist/useDarkMode'
+import mediaQueryListMock from './mocks/MatchMediaQueryList.mock'
+
+const consoleWarnSpy = sinon.spy()
+const realConsoleWarning = console.warn
+const realMatchMedia = window.matchMedia
+
+describe('useDarkMode', () => {
+  before(() => {
+    console.warn = consoleWarnSpy
+    window.matchMedia = () => mediaQueryListMock
+  })
+
+  after(() => {
+    console.warn = realConsoleWarning
+    window.matchMedia = realMatchMedia
+  })
+
+  beforeEach(() => {
+    cleanup()
+  })
+
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  assertHook(useDarkMode)
+
+  it('should set the dark mode to true when the media query matches', () => {
+    const { result } = renderHook(() => useDarkMode())
+
+    expect(result.current.isDarkMode).to.be.true
+  });
+
+  it('should set the dark mode to false when the media query does not match', () => {
+    const updatedMediaQueryListMock = {
+      ...mediaQueryListMock,
+      matches: false
+    }
+
+    window.matchMedia = () => updatedMediaQueryListMock
+
+    const { result } = renderHook(() => useDarkMode())
+
+    expect(result.current.isDarkMode).to.be.true
+
+    window.matchMedia = () => mediaQueryListMock
+  });
+
+  it('should save dark mode to local storage', () => {
+    const { result } = renderHook(() => useDarkMode())
+    const localStorageKey = 'beautiful-react-hooks-is-dark-mode';
+
+    expect(window.localStorage.getItem(localStorageKey)).to.be.eq('true')
+
+    result.current.disable();
+    expect(window.localStorage.getItem(localStorageKey)).to.be.eq('false')
+
+    result.current.enable();
+    expect(window.localStorage.getItem(localStorageKey)).to.be.eq('true')
+
+    result.current.toggle();
+    expect(window.localStorage.getItem(localStorageKey)).to.be.eq('false')
+
+    result.current.disable();
+    expect(window.localStorage.getItem(localStorageKey)).to.be.eq('false')
+  });
+
+  it('should allow user to fully control dark mode state via props and returned functions', () => {
+    const { result } = renderHook(() => useDarkMode(true, 'test_key'))
+
+    expect(result.current.isDarkMode).to.be.true
+
+    result.current.disable();
+    expect(result.current.isDarkMode).to.be.false
+
+    result.current.enable();
+    expect(result.current.isDarkMode).to.be.true
+
+    result.current.toggle();
+    expect(result.current.isDarkMode).to.be.false
+
+    result.current.disable();
+    expect(result.current.isDarkMode).to.be.false
+  });
+})

--- a/test/useIsFirstRender.spec.js
+++ b/test/useIsFirstRender.spec.js
@@ -1,12 +1,12 @@
 import React from 'react'
-import { cleanup as cleanupReact, render } from '@testing-library/react'
+import { cleanup, render } from '@testing-library/react'
 
 import assertHook from './utils/assertHook'
 import useIsFirstRender from '../dist/useIsFirstRender'
 
 describe('useIsFirstRender', () => {
   beforeEach(() => {
-    cleanupReact()
+    cleanup()
   })
 
   assertHook(useIsFirstRender)

--- a/test/useIsFirstRender.spec.js
+++ b/test/useIsFirstRender.spec.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import { cleanup as cleanupReact, render } from '@testing-library/react'
+
+import assertHook from './utils/assertHook'
+import useIsFirstRender from '../dist/useIsFirstRender'
+
+describe('useIsFirstRender', () => {
+  beforeEach(() => {
+    cleanupReact()
+  })
+
+  assertHook(useIsFirstRender)
+
+  it('should return isFirstRender flag set to true before the first render and then always false', () => {
+    const TestComponent = ({ isAfterRerender }) => {
+      const isFirstRender = useIsFirstRender();
+
+      if (!isAfterRerender) {
+        expect(isFirstRender).to.be.eq(true)
+      } else {
+        expect(isFirstRender).to.be.eq(false)
+      }
+
+      return <div />
+    }
+
+    const { rerender } = render(<TestComponent isAfterRerender={false} />)
+
+    rerender(<TestComponent isAfterRerender />)
+    rerender(<TestComponent isAfterRerender />)
+  })
+})

--- a/test/useMediaQuery.spec.js
+++ b/test/useMediaQuery.spec.js
@@ -1,19 +1,10 @@
 import { cleanup, renderHook } from '@testing-library/react-hooks'
-import useMediaQuery from '../dist/useMediaQuery'
+
 import assertHook from './utils/assertHook'
+import useMediaQuery from '../dist/useMediaQuery'
+import mediaQueryListMock from './mocks/MatchMediaQueryList.mock'
 
 describe('useMediaQuery', () => {
-  const mediaQueryListMock = {
-    listeners: {},
-    matches: true,
-    addEventListener(cb) {
-      this.listeners.cb = cb
-    },
-    removeListener() {
-      delete this.listeners.cb
-    }
-  }
-
   beforeEach(() => {
     cleanup()
   })

--- a/test/useUpdateEffect.spec.js
+++ b/test/useUpdateEffect.spec.js
@@ -1,0 +1,30 @@
+import { useEffect } from 'react'
+import { cleanup, renderHook } from '@testing-library/react-hooks'
+
+import assertHook from './utils/assertHook'
+import useUpdateEffect from '../dist/useUpdateEffect'
+
+describe('useUpdateEffect', () => {
+  beforeEach(() => {
+    cleanup()
+  })
+
+  assertHook(useUpdateEffect)
+
+  it('should represent directly the difference between useEffect and useUpdateEffect', () => {
+    const useEffectCallbackSpy = sinon.spy()
+    const useUpdateEffectCallbackSpy = sinon.spy()
+
+    const { rerender: rerenderUseEffect } = renderHook(() => useEffect(useEffectCallbackSpy))
+    const { rerender: rerenderUseUpdateEffect } = renderHook(() => useUpdateEffect(useUpdateEffectCallbackSpy))
+
+    expect(useEffectCallbackSpy.called).to.be.true
+    expect(useUpdateEffectCallbackSpy.called).to.be.false
+
+    rerenderUseEffect();
+    rerenderUseUpdateEffect()
+
+    expect(useEffectCallbackSpy.called).to.be.true
+    expect(useUpdateEffectCallbackSpy.called).to.be.true
+  })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Basically looking at issues I've found one need for useDarkMode so I made it. To achieve this I've created 2 additional hooks `useIsFirstRender` and `useUpdateEffect`. The important thing to mention is that this hook uses a `prefers-color-scheme` to detect the user's operating system theme. Information about the user's dark mode is saved in the local storage. The hook is SSR safe and allows the user to manage dark mode via returned functions such as: `disable`, `enable` and `toggle`. To get access to the current dark mode state just destruct `isDarkMode` flag and that's it!

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#317

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#317

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Test coverage,
2. Examples from docs, 

## Screenshots (if appropriate):
none