### PR TITLE
fix: allow user to change passive flag for change events

### DIFF
--- a/docs/useSwipeEvents.md
+++ b/docs/useSwipeEvents.md
@@ -93,7 +93,7 @@ import useSwipeEvents from 'beautiful-react-hooks/useSwipeEvents';
 
 const SwipeReporter = () => {
   const ref = useRef();
-  const options = { threshold: 25, preventDefault: false };
+  const options = { threshold: 25, preventDefault: false, usePassiveEvents: true };
   const { onSwipeLeft, onSwipeRight, onSwipeUp, onSwipeDown } = useSwipeEvents(ref, options);
   const [lastSwipeInfo, setLastSwipeInfo] = useState();
 

--- a/src/useMouseEvents.ts
+++ b/src/useMouseEvents.ts
@@ -15,15 +15,15 @@ import useEvent from './useEvent'
  * lose the React SyntheticEvent performance boost.<br />
  * If you were doing something like the following:
  */
-const useMouseEvents = <TElement extends HTMLElement>(targetRef?: RefObject<TElement>) => {
+const useMouseEvents = <TElement extends HTMLElement>(targetRef?: RefObject<TElement>, usePassiveEvents?: boolean) => {
   const target = targetRef || { current: window.document } as unknown as RefObject<TElement>
-  const onMouseDown = useEvent<MouseEvent, TElement>(target, 'mousedown')
-  const onMouseEnter = useEvent<MouseEvent, TElement>(target, 'mouseenter')
-  const onMouseLeave = useEvent<MouseEvent, TElement>(target, 'mouseleave')
-  const onMouseMove = useEvent<MouseEvent, TElement>(target, 'mousemove')
-  const onMouseOut = useEvent<MouseEvent, TElement>(target, 'mouseout')
-  const onMouseOver = useEvent<MouseEvent, TElement>(target, 'mouseover')
-  const onMouseUp = useEvent<MouseEvent, TElement>(target, 'mouseup')
+  const onMouseDown = useEvent<MouseEvent, TElement>(target, 'mousedown', { passive: usePassiveEvents })
+  const onMouseEnter = useEvent<MouseEvent, TElement>(target, 'mouseenter', { passive: usePassiveEvents })
+  const onMouseLeave = useEvent<MouseEvent, TElement>(target, 'mouseleave', { passive: usePassiveEvents })
+  const onMouseMove = useEvent<MouseEvent, TElement>(target, 'mousemove', { passive: usePassiveEvents })
+  const onMouseOut = useEvent<MouseEvent, TElement>(target, 'mouseout', { passive: usePassiveEvents })
+  const onMouseOver = useEvent<MouseEvent, TElement>(target, 'mouseover', { passive: usePassiveEvents })
+  const onMouseUp = useEvent<MouseEvent, TElement>(target, 'mouseup', { passive: usePassiveEvents })
 
   return Object.freeze({
     onMouseDown,

--- a/src/useSwipe.ts
+++ b/src/useSwipe.ts
@@ -7,12 +7,14 @@ export type UseSwipeOptions = {
   direction?: 'both' | 'horizontal' | 'vertical',
   threshold?: number,
   preventDefault?: boolean,
+  usePassiveEvents?: boolean
 }
 
 const defaultOptions: UseSwipeOptions = {
   direction: 'both',
   threshold: 10,
   preventDefault: true,
+  usePassiveEvents: undefined,
 }
 
 type LocalSwipeState = {
@@ -41,8 +43,8 @@ const useSwipe = <TElement extends HTMLElement>(targetRef: RefObject<TElement> =
   const startingPointRef = useRef<[number, number]>([-1, -1])
   const isDraggingRef = useRef(false)
   const opts = { ...defaultOptions, ...(options || {}) }
-  const { onMouseDown, onMouseMove, onMouseLeave, onMouseUp } = useMouseEvents<TElement>(targetRef)
-  const { onTouchStart, onTouchMove, onTouchEnd, onTouchCancel } = useTouchEvents<TElement>(targetRef)
+  const { onMouseDown, onMouseMove, onMouseLeave, onMouseUp } = useMouseEvents<TElement>(targetRef, opts.usePassiveEvents)
+  const { onTouchStart, onTouchMove, onTouchEnd, onTouchCancel } = useTouchEvents<TElement>(targetRef, opts.usePassiveEvents)
 
   const startSwipe = (event: MouseEvent | TouchEvent) => {
     const [clientX, clientY] = getPointerCoordinates(event)

--- a/src/useSwipeEvents.ts
+++ b/src/useSwipeEvents.ts
@@ -22,7 +22,6 @@ const defaultOptions: UseSwipeEventsOpts = {
   threshold: 15,
   preventDefault: true,
   usePassiveEvents: undefined,
-
 }
 /* eslint-disable @typescript-eslint/default-param-last */
 

--- a/src/useSwipeEvents.ts
+++ b/src/useSwipeEvents.ts
@@ -15,11 +15,14 @@ export type SwipeState = {
 export type UseSwipeEventsOpts = {
   threshold?: number,
   preventDefault?: boolean,
+  usePassiveEvents?: boolean,
 }
 
 const defaultOptions: UseSwipeEventsOpts = {
   threshold: 15,
   preventDefault: true,
+  usePassiveEvents: undefined,
+
 }
 /* eslint-disable @typescript-eslint/default-param-last */
 
@@ -37,8 +40,8 @@ const useSilentSwipeState = <TElement extends HTMLElement>(
   const isDraggingRef = useRef(false)
   const alphaRef = useRef<number[]>([])
   const opts = { ...defaultOptions, ...(options || {}) }
-  const { onMouseDown, onMouseMove, onMouseLeave, onMouseUp } = useMouseEvents<TElement>(targetRef)
-  const { onTouchStart, onTouchMove, onTouchEnd, onTouchCancel } = useTouchEvents<TElement>(targetRef)
+  const { onMouseDown, onMouseMove, onMouseLeave, onMouseUp } = useMouseEvents<TElement>(targetRef, opts.usePassiveEvents)
+  const { onTouchStart, onTouchMove, onTouchEnd, onTouchCancel } = useTouchEvents<TElement>(targetRef, opts.usePassiveEvents)
   const [state, setState] = useState<SwipeState>()
 
   const startSwipe = (event: MouseEvent | TouchEvent) => {

--- a/src/useTouchEvents.ts
+++ b/src/useTouchEvents.ts
@@ -16,12 +16,12 @@ import useEvent from './useEvent'
  * If you were doing something like the following:
  *
  */
-const useTouchEvents = <TElement extends HTMLElement>(targetRef?: RefObject<TElement>) => {
+const useTouchEvents = <TElement extends HTMLElement>(targetRef?: RefObject<TElement>, usePassiveEvents?: boolean) => {
   const target = targetRef || { current: window.document } as unknown as RefObject<TElement> // hackish but works
-  const onTouchStart = useEvent<TouchEvent, TElement>(target, 'touchstart')
-  const onTouchEnd = useEvent<TouchEvent, TElement>(target, 'touchend')
-  const onTouchCancel = useEvent<TouchEvent, TElement>(target, 'touchcancel')
-  const onTouchMove = useEvent<TouchEvent, TElement>(target, 'touchmove')
+  const onTouchStart = useEvent<TouchEvent, TElement>(target, 'touchstart', { passive: usePassiveEvents })
+  const onTouchEnd = useEvent<TouchEvent, TElement>(target, 'touchend', { passive: usePassiveEvents })
+  const onTouchCancel = useEvent<TouchEvent, TElement>(target, 'touchcancel', { passive: usePassiveEvents })
+  const onTouchMove = useEvent<TouchEvent, TElement>(target, 'touchmove', { passive: usePassiveEvents })
 
   return Object.freeze({
     onTouchStart,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Not much to describe. For now, the user can decide if events should be passive or not

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#258

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#258

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Via enabe/diable passive events and observe console result.

## Screenshots (if appropriate):
none