### PR TITLE
Fix isBottom in the useInfiniteScroll

### DIFF
--- a/src/useInfiniteScroll.ts
+++ b/src/useInfiniteScroll.ts
@@ -20,7 +20,7 @@ const useInfiniteScroll = <TElement extends HTMLElement>(ref: RefObject<TElement
   const handleScroll = useCallback(({ target }: UIEvent) => {
     const el = target as HTMLDivElement
     if (el) {
-      const isBottom = el.scrollHeight - el.scrollTop === el.clientHeight
+      const isBottom = Math.abs(el.scrollHeight - el.clientHeight - el.scrollTop) < 1
       if (isBottom && isFunction(onScrollEnd?.current)) {
         setTimeout(onScrollEnd.current, delay)
       }


### PR DESCRIPTION
> scrollTop is a non-rounded number, while scrollHeight and clientHeight are rounded — so the only way to determine if the scroll area is scrolled to the bottom is by seeing if the scroll amount is close enough to some threshold (in this example 1):
> 
> `Math.abs(element.scrollHeight - element.clientHeight - element.scrollTop) < 1`
> 
> The following will not work all the time because scrollTop can contain decimals:
> 
> `element.scrollHeight - Math.abs(element.scrollTop) === element.clientHeight`

[Source](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight)
