### PR TITLE
🐛  useLocalStorage no longer returns a new setValue function every time setValue is called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -993,3 +993,9 @@ Errored release
 ### Fixes
 
 - Fixes `useInfiniteScroll` console.error message
+
+## [3.12.3] - 2023-02-16
+
+### Fixes
+
+- `useLocalStorage` and `useSessionStorage` no longer return a new `setValue` function everytime `setValue` is called

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beautiful-react-hooks",
-  "version": "3.12.2",
+  "version": "3.12.3",
   "description": "A collection of beautiful (and hopefully useful) React hooks to speed-up your components and hooks development",
   "main": "index.js",
   "module": "esm/index.js",

--- a/src/factory/createStorageHook.ts
+++ b/src/factory/createStorageHook.ts
@@ -54,11 +54,16 @@ const createStorageHook = (type: 'session' | 'local') => {
       },
     )
 
-    const setValue: SetValue<TValue> = useCallback((value) => {
-      const valueToStore = value instanceof Function ? value(storedValue) : value
-      safelySetStorage(JSON.stringify(valueToStore))
-      setStoredValue(valueToStore)
-    }, [safelySetStorage, storedValue])
+    const setValue: SetValue<TValue> = useCallback(
+      (value: TValue) => {
+        setStoredValue((current: TValue) => {
+          const valueToStore = value instanceof Function ? value(current) : value
+          safelySetStorage(JSON.stringify(valueToStore))
+          return valueToStore
+        })
+      },
+      [safelySetStorage]
+    )
 
     return [storedValue, setValue]
   }

--- a/test/useLocalStorage.spec.js
+++ b/test/useLocalStorage.spec.js
@@ -101,4 +101,18 @@ describe('useLocalStorage', () => {
 
     expect(result.current[0]).to.equal(200)
   })
+
+  it("should return the same setValue reference after setValue is called", () => {
+    const { result } = renderHook(() =>
+      useLocalStorage("storageKey_7", 100)
+    )
+
+    const startingSetValue = result.current[1]
+
+    act(() => {
+      result.current[1](prev => prev + 100)
+    })
+    
+    expect(result.current[1]).to.equal(startingSetValue)
+  })
 })

--- a/test/useSessionStorage.spec.js
+++ b/test/useSessionStorage.spec.js
@@ -99,4 +99,18 @@ describe('useSessionStorage', () => {
 
     expect(result.current[0]).to.equal(200)
   })
+
+  it("should return the same setValue reference after setValue is called", () => {
+    const { result } = renderHook(() =>
+      useSessionStorage("storageKey_7", 100)
+    )
+
+    const startingSetValue = result.current[1]
+
+    act(() => {
+      result.current[1](prev => prev + 100)
+    })
+    
+    expect(result.current[1]).to.equal(startingSetValue)
+  })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Instead of using `storedValue` as a dependency within the `setValue` callback in `createStorageHook.ts` we are getting the current stored value from `setStoredValue` directly. This stops the `setValue` callback from unnecessarily being recreated every time the storedValue changes.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/antonioru/beautiful-react-hooks/issues/395

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I was getting an infinite loop when `setValue` was used as a dependency on a useEffect where the effect was calling `setValue`.
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/antonioru/beautiful-react-hooks/issues/395

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Added additional unit tests.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
