### PR TITLE
Check typeof process.env for isDevelopment

### DIFF
--- a/src/shared/isDevelopment.ts
+++ b/src/shared/isDevelopment.ts
@@ -1,5 +1,5 @@
 const isDevelopment = (
-  typeof process !== 'undefined' && process.env && (!process.env.NODE_ENV || process.env.NODE_ENV === 'development')
+  typeof process !== 'undefined' && typeof process.env !== 'undefined' && (!process.env.NODE_ENV || process.env.NODE_ENV === 'development')
 )
 
 export default isDevelopment


### PR DESCRIPTION
When you build this file with webpack it will add all the process.env variables in the final production build, this will fix it


## Description

this will be in the output if you check the process.env
"undefined"!==typeof process&&{NODE_ENV:"production",PUBLIC_URL:"",REACT_APP_BRANCH_NAME:"local"}&&!1

