### PR TITLE
add useCallback to useObjectState to avoid redundant useEffect runs

### DIFF
--- a/src/useObjectState.ts
+++ b/src/useObjectState.ts
@@ -1,4 +1,4 @@
-import { useReducer } from 'react'
+import { useCallback, useReducer } from 'react'
 
 const reducer = <TState>(
   previousState: TState,
@@ -16,7 +16,7 @@ const useObjectState = <TState>(
     initialState
   )
 
-  const setState = (updatedState: Partial<TState>): void => { dispatch(updatedState) }
+  const setState = useCallback((updatedState: Partial<TState>): void => { dispatch(updatedState) }, [dispatch])
 
   return [state, setState]
 }


### PR DESCRIPTION
When giving useEffect the setState as dependance, it will rerun every time because we didn't use useCallback.

## Description
add useCallback to useObjectState to avoid redundant useEffect runs

dispatch of useReducer is consistent, as we can see [here](https://legacy.reactjs.org/docs/hooks-reference.html#usereducer:~:text=React%20guarantees%20that%20dispatch%20function%20identity%20is%20stable%20and%20won%E2%80%99t%20change%20on%20re%2Drenders.%20This%20is%20why%20it%E2%80%99s%20safe%20to%20omit%20from%20the%20useEffect%20or%20useCallback%20dependency%20list.).
