### PR TITLE
Update react and react-dom peer dependency to ^18.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "lodash.throttle": "^4.1.1"
   },
   "peerDependencies": {
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "react-router-dom": ">=5.0.0",
     "rxjs": ">=7.0.0"
   },


### PR DESCRIPTION
## Description
Updated the react and react-dom peer dependency in `package.json` to "^18.2.0" to allow installation of later versions while maintaining compatibility with the package.

## Related Issue
Fixes #423  

## Motivation and Context
This change is necessary to address the issue of restricting the installation of later versions of React due to the exact version requirement in the peer dependency configuration of beautiful-react-hooks.

## How Has This Been Tested?
Conducted basic tests by running `npm test` and `npm build` to ensure that the package can still be built and tested successfully after updating the React peer dependency.



